### PR TITLE
fix(session): ensure proper cleanup of inflight messages on publish failure

### DIFF
--- a/rmqtt/src/session.rs
+++ b/rmqtt/src/session.rs
@@ -915,11 +915,17 @@ impl SessionState {
                     }
                     Ok(res) => res,
                 };
-                self.publish(publish).await?;
-                sink.send_publish_ack(packet_id).await?;
+                self.publish(publish).await.map_err(|e| {
+                    if inflight_res {
+                        self.in_inflight.remove(&packet_id);
+                    }
+                    e
+                })?;
+                let ack_res = sink.send_publish_ack(packet_id).await;
                 if inflight_res {
                     self.in_inflight.remove(&packet_id);
                 }
+                ack_res?;
             }
             QoS::ExactlyOnce => {
                 let packet_id = Self::packet_id(packet_id)?;

--- a/rmqtt/src/session.rs
+++ b/rmqtt/src/session.rs
@@ -915,11 +915,10 @@ impl SessionState {
                     }
                     Ok(res) => res,
                 };
-                self.publish(publish).await.map_err(|e| {
+                self.publish(publish).await.inspect_err(|_| {
                     if inflight_res {
                         self.in_inflight.remove(&packet_id);
                     }
-                    e
                 })?;
                 let ack_res = sink.send_publish_ack(packet_id).await;
                 if inflight_res {


### PR DESCRIPTION
- Added error mapping to remove inflight entry if `publish()` fails
- Separated ACK sending from publish operation for better error handling
- Guaranteed inflight message cleanup in both success and error cases

This prevents resource leaks when QoS 1 message publishing fails by ensuring the inflight tracking is properly maintained.